### PR TITLE
[BUGFIX] - Broken messages container styling and scrolling

### DIFF
--- a/frontend/src/chat/components/Chat/Chat.svelte
+++ b/frontend/src/chat/components/Chat/Chat.svelte
@@ -47,16 +47,16 @@
 	}
 
 	.sidebar__header {
-		padding: 24px;
-		height: 64px;
+		padding: 25px;
+		height: 50px;
 	}
 
 	.sidebar__body {
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-end;
-		height: calc(100% - 120px);
-		padding: 0 24px;
+		display:flex;
+        flex-direction: column-reverse;
+		overflow-x: auto;
+        height: calc(100% - 120px);
+		padding: 0px 24px;
 	}
 
 	.sidebar__footer {


### PR DESCRIPTION
- Since justify-content: flex-end and overflow: auto don't play along, using flex-direction: column-reverse; to display message at the bottom.

- Fixed styling of the container